### PR TITLE
MDT-28: Add ESLint configuration to enforce React hooks rules

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,4 @@
+node_modules
+dist
+build
+webpack.config.js

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,35 @@
+{
+  "env": {
+    "browser": true,
+    "es2021": true
+  },
+  "extends": [
+    "eslint:recommended",
+    "plugin:react/recommended",
+    "plugin:react/jsx-runtime",
+    "plugin:react-hooks/recommended",
+    "plugin:@typescript-eslint/recommended"
+  ],
+  "parser": "@typescript-eslint/parser",
+  "parserOptions": {
+    "ecmaFeatures": {
+      "jsx": true
+    },
+    "ecmaVersion": "latest",
+    "sourceType": "module"
+  },
+  "plugins": [
+    "react",
+    "react-hooks",
+    "@typescript-eslint"
+  ],
+  "rules": {
+    "react-hooks/rules-of-hooks": "error",
+    "react-hooks/exhaustive-deps": "warn"
+  },
+  "settings": {
+    "react": {
+      "version": "detect"
+    }
+  }
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,12 @@
+{
+  "eslint.enable": true,
+  "eslint.validate": [
+    "javascript",
+    "javascriptreact",
+    "typescript",
+    "typescriptreact"
+  ],
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": "explicit"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -10,8 +10,13 @@
     "@types/jest": "^30.0.0",
     "@types/react": "^19.2.8",
     "@types/react-dom": "^19.2.3",
+    "@typescript-eslint/eslint-plugin": "^8.20.0",
+    "@typescript-eslint/parser": "^8.20.0",
     "babel-loader": "^10.0.0",
     "css-loader": "^7.1.2",
+    "eslint": "^9.21.0",
+    "eslint-plugin-react": "^7.37.3",
+    "eslint-plugin-react-hooks": "^5.1.0",
     "html-webpack-plugin": "^5.6.5",
     "prettier": "^3.7.4",
     "style-loader": "^4.0.0",
@@ -31,6 +36,8 @@
     "build": "webpack --mode production",
     "typecheck": "tsc --noEmit",
     "format": "prettier --write \"**/*.{ts,tsx,js,jsx,json,css,md}\"",
-    "format:check": "prettier --check \"**/*.{ts,tsx,js,jsx,json,css,md}\""
+    "format:check": "prettier --check \"**/*.{ts,tsx,js,jsx,json,css,md}\"",
+    "lint": "eslint \"src/**/*.{ts,tsx}\"",
+    "lint:fix": "eslint \"src/**/*.{ts,tsx}\" --fix"
   }
 }


### PR DESCRIPTION
## Summary

This PR implements ESLint configuration to enforce React hooks rules in VSCode, addressing issue #52.

## Changes

- Added ESLint configuration with `eslint-plugin-react-hooks`
- Configured VSCode settings to enable ESLint integration
- Added lint scripts to package.json
- Included TypeScript support in ESLint configuration

Developers will now receive warnings when:
- React hooks rules are violated
- Dependencies are missing from useEffect, useCallback, useMemo, etc.

## Post-Merge Steps

After merging, developers need to:
1. Run `npm install` to install the new ESLint dependencies
2. Install the ESLint VSCode extension if not already installed
3. Restart VSCode to apply the new settings

Closes #52

🤖 Generated with [Claude Code](https://claude.ai/code)