### PR TITLE
MDT-31: Refactor from HTML table to CSS Grid

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -42,8 +42,15 @@ body {
   min-height: 100vh;
 }
 .board {
+  display: grid;
+  grid-template-columns: repeat(4, 107px);
+  grid-template-rows: repeat(4, 107px);
+  gap: 15px;
   background: var(--color-board);
+  padding: 15px;
+  border-radius: 3px;
 }
+
 .tile {
   width: 107px;
   height: 107px;
@@ -52,25 +59,12 @@ body {
   font-weight: bold;
   text-align: center;
   background: var(--color-tile-empty);
-}
-
-.tile-moving {
-  animation: tile-move 150ms ease-in-out;
-  --tile-offset-x: 0px;
-  --tile-offset-y: 0px;
+  border-radius: 3px;
+  transition: all 150ms ease-in-out;
 }
 
 .tile-new {
   animation: tile-pop 200ms ease-in-out;
-}
-
-@keyframes tile-move {
-  0% {
-    transform: translate(var(--tile-offset-x), var(--tile-offset-y));
-  }
-  100% {
-    transform: translate(0, 0);
-  }
 }
 
 @keyframes tile-pop {
@@ -85,13 +79,6 @@ body {
     transform: scale(1);
     opacity: 1;
   }
-}
-
-.board,
-.tile {
-  border: 15px solid var(--color-board);
-  border-collapse: collapse;
-  border-radius: 3px;
 }
 
 .tile-2 {


### PR DESCRIPTION
### Summary

This PR refactors the 2048 game grid from an HTML table to a modern CSS Grid layout, simplifying the animation approach and removing complex inline style calculations.

### Changes

- Convert table-based grid to CSS Grid layout
- Simplify animation approach using CSS transitions
- Remove tile-offset inline styles and complex position tracking
- Remove movingTiles state and tilePositions map
- Keep tile-new animation for newly created tiles

Closes #58

---

Generated with [Claude Code](https://claude.ai/code)