### PR TITLE
Table to CSS grid

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -42,8 +42,20 @@ body {
   min-height: 100vh;
 }
 .board {
+  display: grid;
+  grid-template-columns: repeat(4, 107px);
+  grid-template-rows: repeat(4, 107px);
+  gap: 15px;
+  padding: 15px;
   background: var(--color-board);
+  border-radius: 6px;
 }
+
+.cell {
+  background: var(--color-tile-empty);
+  border-radius: 3px;
+}
+
 .tile {
   width: 107px;
   height: 107px;
@@ -52,25 +64,13 @@ body {
   font-weight: bold;
   text-align: center;
   background: var(--color-tile-empty);
-}
-
-.tile-moving {
-  animation: tile-move 150ms ease-in-out;
-  --tile-offset-x: 0px;
-  --tile-offset-y: 0px;
+  border-radius: 3px;
+  z-index: 1;
+  transition: transform 150ms ease-in-out;
 }
 
 .tile-new {
   animation: tile-pop 200ms ease-in-out;
-}
-
-@keyframes tile-move {
-  0% {
-    transform: translate(var(--tile-offset-x), var(--tile-offset-y));
-  }
-  100% {
-    transform: translate(0, 0);
-  }
 }
 
 @keyframes tile-pop {
@@ -85,13 +85,6 @@ body {
     transform: scale(1);
     opacity: 1;
   }
-}
-
-.board,
-.tile {
-  border: 15px solid var(--color-board);
-  border-collapse: collapse;
-  border-radius: 3px;
 }
 
 .tile-2 {


### PR DESCRIPTION
Replace HTML table with CSS Grid for rendering the game board.

This change simplifies tile movement animations by leveraging CSS `transform` transitions and removes the need for inline `tile-offset` styles and a custom animation class.

---
<a href="https://cursor.com/background-agent?bcId=bc-2b1dc960-48b5-4bd4-b49b-5bf4c5e10fc5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2b1dc960-48b5-4bd4-b49b-5bf4c5e10fc5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

