### PR TITLE
Page background highest tile

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -32,6 +32,7 @@
 body {
   color: var(--color-text-dark);
   font-family: "Clear Sans", "Helvetica Neue", Arial, sans-serif;
+  transition: background-color 0.3s ease-in-out;
 }
 
 .App {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,6 +17,28 @@ import "./App.css"
 
 const WINNING_TILE = 2048
 
+// Tile background colors matching CSS variables
+const TILE_COLORS: Record<number, string> = {
+  2: "#eee4da",
+  4: "#ede0c8",
+  8: "#f2b179",
+  16: "#f59563",
+  32: "#f67c5f",
+  64: "#f65e3b",
+  128: "#edcf72",
+  256: "#edcc61",
+  512: "#edc850",
+  1024: "#edc53f",
+  2048: "#edc22e",
+}
+
+// Default background color when no tiles or unknown tile value
+const DEFAULT_BACKGROUND = "#faf8ef"
+
+function getTileColor(value: number): string {
+  return TILE_COLORS[value] ?? DEFAULT_BACKGROUND
+}
+
 type MoveFunction = (board: Board) => Board | null
 
 const keyMove: Record<string, MoveFunction> = {
@@ -205,6 +227,12 @@ function App(): React.JSX.Element {
   }, [handleKeyDown])
 
   const currentScore = getHighestTile(board)
+
+  // Update page background color based on highest tile
+  useEffect(() => {
+    const backgroundColor = getTileColor(currentScore)
+    document.body.style.backgroundColor = backgroundColor
+  }, [currentScore])
   const currentTimeInSeconds = Math.floor((Date.now() - startTime) / 1000)
 
   return (


### PR DESCRIPTION
Implement MDT-39: Page background color matches the highest tile value on the board.

---
<a href="https://cursor.com/background-agent?bcId=bc-5981aec3-9d8e-4363-b13e-c1bf378200ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5981aec3-9d8e-4363-b13e-c1bf378200ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

